### PR TITLE
load new game

### DIFF
--- a/src/anybody.js
+++ b/src/anybody.js
@@ -14,6 +14,20 @@ export class Anybody extends EventEmitter {
     Object.assign(this, Visuals)
     Object.assign(this, Calculations)
 
+    this.setOptions(options)
+
+    // Add other constructor logic here
+    this.p = p
+    // this.p.blendMode(this.p.DIFFERENCE)
+
+    !this.util && this.prepareP5()
+    this.clearValues()
+    this.sound = new Sound(this)
+    this.init()
+    !this.util && this.start()
+  }
+
+  setOptions(options = {}) {
     const defaultOptions = {
       inputData: null,
       bodyData: null,
@@ -47,22 +61,10 @@ export class Anybody extends EventEmitter {
       faceRotation: 'hitcycle', // 'time' or 'hitcycle' or 'mania'
       sfx: 'bubble' // 'space' or 'bubble'
     }
-
     // Merge the default options with the provided options
     const mergedOptions = { ...defaultOptions, ...options }
-
     // Assign the merged options to the instance properties
     Object.assign(this, mergedOptions)
-
-    // Add other constructor logic here
-    this.p = p
-    // this.p.blendMode(this.p.DIFFERENCE)
-
-    !this.util && this.prepareP5()
-    this.clearValues()
-    this.sound = new Sound(this)
-    this.init()
-    !this.util && this.start()
   }
 
   // run whenever the class should be reset
@@ -252,7 +254,12 @@ export class Anybody extends EventEmitter {
     this.emit('gameOver', { won, ticks: this.frames - this.startingFrame })
   }
 
-  playAgain = () => {
+  playAgain = (options) => {
+    if (options) {
+      // TODO: maybe save initial options so that we can reuse them and just update specific values?
+      // that could get messy tho too...
+      this.setOptions(options)
+    }
     this.clearValues()
     this.sound?.stop()
     this.init()

--- a/src/anybody.js
+++ b/src/anybody.js
@@ -256,8 +256,6 @@ export class Anybody extends EventEmitter {
 
   playAgain = (options) => {
     if (options) {
-      // TODO: maybe save initial options so that we can reuse them and just update specific values?
-      // that could get messy tho too...
       this.setOptions(options)
     }
     this.clearValues()


### PR DESCRIPTION
@psugihara what do you think of this approach?

Basically it makes optional parameter called `options` on `playAgain` that allows you to re-configure starting conditions of the anybody object.

this way you have to set all the options anew, but we could also save initial options so that only overwrites go into the `playAgain`. What do you think is better? Could also be messy cause you have to check what the original settings were each time?