### PR TITLE
bind methods to anybody object

### DIFF
--- a/src/anybody.js
+++ b/src/anybody.js
@@ -20,8 +20,15 @@ export class Anybody extends EventEmitter {
   constructor(p, options = {}) {
     super()
 
-    Object.assign(this, Visuals)
-    Object.assign(this, Calculations)
+    const methods = {}
+    Object.assign(methods, Visuals)
+    Object.assign(methods, Calculations)
+    Object.keys(methods).forEach((key) => {
+      if (typeof this[key] === 'function') {
+        this[key] = this[key].bind(this)
+      }
+    })
+    Object.assign(this, methods)
 
     this.setOptions(options)
 


### PR DESCRIPTION
This fixes the restart button on the game over screen. I'm not sure why it was working before but not now. This fixes anyway.