### PR TITLE
fix success screen overflow

### DIFF
--- a/src/anybody.js
+++ b/src/anybody.js
@@ -323,10 +323,9 @@ export class Anybody extends EventEmitter {
 
   setStatsText = async (stats) => {
     const statLines = [
-      // `total bodies: ${stats.bodiesIncluded}`,
-      `¸¸♬·¯·♩¸¸♪·¯·♫¸¸♬·¯·♩¸¸♪·¯`,
+      `¸¸♬·¯·♩¸♪··♫¸¸♫··♪¸♩·¯·♬¸¸`,
       `${stats.bodiesIncluded} body score: ${stats.bodiesBoost}`,
-      `speed bonus (${stats.timeTook}s): ${stats.speedBoost}x`,
+      `speed bonus (${stats.timeTook.toFixed(2)}s): ${stats.speedBoost}x`,
       `DU$T earned: ${stats.dust}`
     ]
     const toShow = statLines.join('\n')


### PR DESCRIPTION
@okwme I think we have some discrepancy between out music note rendering. They look much smaller in your screenshot in #130 than they look on my screen but lmk what you see with this change.



<img width="644" alt="Screenshot 2024-05-01 at 12 35 06 PM" src="https://github.com/trifle-labs/anybody-problem/assets/282016/5a4907d0-5fee-4d9a-925b-856b578b6f4f">
