### PR TITLE
api: add back wallet/address support, add longest streaks

### DIFF
--- a/server/shovel-config.ts
+++ b/server/shovel-config.ts
@@ -53,7 +53,8 @@ const baseSepolia: KnownSource = {
   chain_id: 84532,
   url: process.env.BASE_SEPOLIA_RPC,
   batch_size: 1000,
-  concurrency: 1
+  concurrency: 1,
+  poll_duration: '12s'
 }
 
 const solTypeToPgType: Record<string, PGColumnType> = {

--- a/server/shovel-config.ts
+++ b/server/shovel-config.ts
@@ -53,8 +53,8 @@ const baseSepolia: KnownSource = {
   chain_id: 84532,
   url: process.env.BASE_SEPOLIA_RPC,
   batch_size: 1000,
-  concurrency: 1,
-  poll_duration: '12s'
+  concurrency: 1
+  // poll_duration: '12s' // default is 1s, uncomment for slower polling in dev
 }
 
 const solTypeToPgType: Record<string, PGColumnType> = {

--- a/server/src/demo.html
+++ b/server/src/demo.html
@@ -7,7 +7,7 @@
 
   <body>
     <h1>
-      Anybody API /sse/base_sepolia/0xFa398d672936Dcf428116F687244034961545D91
+      Anybody API /sse/base_sepolia/0xfa398d672936dcf428116f687244034961545d91
     </h1>
     <pre id="sse-data"></pre>
 
@@ -17,7 +17,7 @@
       const controller = new AbortController()
       const signal = controller.signal
       const response = await fetch(
-        '/sse/base_sepolia/0xFa398d672936Dcf428116F687244034961545D91',
+        '/sse/base_sepolia/0xfa398d672936dcf428116f687244034961545d91',
         {
           method: 'POST',
           headers: { 'Content-Type': 'text/event-stream' },

--- a/server/src/demo.html
+++ b/server/src/demo.html
@@ -6,7 +6,9 @@
   </head>
 
   <body>
-    <h1>Anybody API /sse/base_sepolia</h1>
+    <h1>
+      Anybody API /sse/base_sepolia/0xFa398d672936Dcf428116F687244034961545D91
+    </h1>
     <pre id="sse-data"></pre>
 
     <script type="module">
@@ -14,11 +16,14 @@
 
       const controller = new AbortController()
       const signal = controller.signal
-      const response = await fetch('/sse/base_sepolia', {
-        method: 'POST',
-        headers: { 'Content-Type': 'text/event-stream' },
-        signal
-      })
+      const response = await fetch(
+        '/sse/base_sepolia/0xFa398d672936Dcf428116F687244034961545D91',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'text/event-stream' },
+          signal
+        }
+      )
 
       const reader = response.body
         .pipeThrough(new TextDecoderStream())

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -86,6 +86,7 @@ async function* streamGenerator(
     yield {
       data: JSON.stringify({
         leaderboard: leaderboards[chain],
+        wallet: await wallet(chain, address),
         address
       }),
       event: 'message',

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -50,7 +50,7 @@ setupListener()
 
 // uncomment to test the connection
 // setInterval(async () => {
-//   await updateLeaderboard('sepolia')
+//   await updateLeaderboard('base_sepolia')
 //   await publish()
 // }, 3000)
 
@@ -121,11 +121,13 @@ app.use(
 )
 
 app.post('/sse/:chain', async (c) => {
+  c.header('X-Accel-Buffering', 'no')
   const chain = c.req.param('chain') as Chain
   return streamSSE(c, streamHandler(c.req.raw.signal, chain))
 })
 
 app.post('/sse/:chain/:address', async (c) => {
+  c.header('X-Accel-Buffering', 'no')
   const address = c.req.param('address')
   const chain = c.req.param('chain') as Chain
   return streamSSE(c, streamHandler(c.req.raw.signal, chain, address))

--- a/server/src/leaderboard.ts
+++ b/server/src/leaderboard.ts
@@ -1,5 +1,6 @@
 import { Chain } from '../shovel-config'
 import db from './db'
+import { currentDayInUnixTime } from './util'
 
 type LeaderboardLine = {
   player: string
@@ -44,12 +45,6 @@ const MAX_BODY_COUNT = 6
 const DAILY_CATEGORY_LIMIT = 3
 
 export const leaderboards: Record<Chain, Leaderboard> | {} = {}
-
-function currentDayInUnixTime() {
-  const date = new Date()
-  date.setUTCHours(0, 0, 0, 0)
-  return date.getTime() / 1000
-}
 
 async function calculateDailyLeaderboard(day: number, chain: Chain) {
   const q = `

--- a/server/src/util.ts
+++ b/server/src/util.ts
@@ -1,3 +1,9 @@
 export function camelToSnakeCase(str: string) {
   return str.replace(/([a-z])([A-Z])/g, '$1_$2').toLowerCase()
 }
+
+export function currentDayInUnixTime() {
+  const date = new Date()
+  date.setUTCHours(0, 0, 0, 0)
+  return date.getTime() / 1000
+}

--- a/server/src/wallet.ts
+++ b/server/src/wallet.ts
@@ -1,0 +1,91 @@
+import { Chain } from '../shovel-config'
+import db from './db'
+
+async function getOwnedBodies(chain: Chain, address?: string) {
+  if (!address) return []
+
+  const problems = await db.query(
+    `
+    WITH latest_transactions AS (
+      SELECT
+          token_id,
+          "to",
+          ROW_NUMBER() OVER (PARTITION BY token_id ORDER BY block_num DESC, tx_idx DESC, log_idx DESC) AS rn
+      FROM
+        problems_transfer
+      WHERE
+        "to" = decode($1, 'hex')
+        AND src_name = '${chain}'
+  ),
+  current_owners AS (
+      SELECT
+          token_id
+      FROM
+          latest_transactions
+      WHERE
+          rn = 1
+  ),
+  body_add_remove_events AS (
+      SELECT
+          ba.problem_id,
+          ba.body_id,
+          ba.block_num,
+          ba.tx_idx,
+          ba.log_idx,
+          'added' AS status
+      FROM
+      problems_body_added ba
+      WHERE src_name = '${chain}'
+      UNION ALL
+      SELECT
+          br.problem_id,
+          br.body_id,
+          br.block_num,
+          br.tx_idx,
+          br.log_idx,
+          'removed' AS status
+      FROM
+      problems_body_removed br
+      WHERE src_name = '${chain}'
+  ),
+  body_final_status AS (
+      SELECT
+          problem_id,
+          body_id,
+          status,
+          ROW_NUMBER() OVER (PARTITION BY problem_id, body_id ORDER BY block_num DESC, tx_idx DESC, log_idx DESC) AS rn
+      FROM
+          body_add_remove_events
+  )
+  SELECT
+      ba.problem_id,
+      ba.body_id,
+      ba.minted_body_index,
+      ba.tick,
+      ba.px,
+      ba.py,
+      ba.radius,
+      CONCAT('0x', encode(ba.seed, 'hex')) AS seed,
+      CONCAT('0x', encode(ba.log_addr, 'hex')) AS log_addr
+  FROM
+    problems_body_added ba
+  JOIN
+      current_owners co ON ba.problem_id = co.token_id
+  JOIN
+      body_final_status bfs ON ba.problem_id = bfs.problem_id AND ba.body_id = bfs.body_id
+  WHERE
+      bfs.rn = 1
+      AND bfs.status = 'added';`,
+    [address.replace(/^0x/, '')]
+  )
+
+  return problems.rows
+}
+
+export default async function wallet(chain: Chain, address?: string) {
+  if (!address) return {}
+  const start = Date.now()
+  const bodies = await getOwnedBodies(chain, address)
+  console.log('wallet', address, 'queried in', Date.now() - start, 'ms')
+  return { bodies }
+}


### PR DESCRIPTION
- add back wallet/address support
- add longest streaks to wallet and leaderboard results
- add X-Accel-Buffering to maybe avoid nginx buffering (recc'd [here](https://ideas.digitalocean.com/app-platform/p/http-response-streaming-in-app-platform-for-sse-support))

<img width="564" alt="Screenshot 2024-07-23 at 3 40 51 PM" src="https://github.com/user-attachments/assets/12e3385a-7cb6-4391-beea-3f144d87b342">
