### PR TITLE
use solidity based randomness for bodyColor and faces

### DIFF
--- a/contracts/ExternalMetadata.sol
+++ b/contracts/ExternalMetadata.sol
@@ -360,6 +360,14 @@ contract ExternalMetadata is Ownable {
         return path;
     }
 
+    // NOTE: I think this could actually be returning HSL and then we don't need to implement conversion
+    function getBodyColor(
+        uint256 day,
+        uint256 bodyIndex
+    ) public pure returns (uint256[3] memory rgb) {
+        if (bodyIndex == 0) {} else {}
+    }
+
     function seedToColor(bytes32 seed) public pure returns (string memory) {
         uint256 blocker = 0xffff;
         uint256 color = (uint256(seed) & blocker) % 360;

--- a/contracts/ExternalMetadata.sol
+++ b/contracts/ExternalMetadata.sol
@@ -1,12 +1,13 @@
 //SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "base64-sol/base64.sol";
-import "./AnybodyProblem.sol";
-import "./Speedruns.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
-import "./BokkyPooBahsDateTimeLibrary.sol";
-import "./StringsExtended.sol";
+import 'base64-sol/base64.sol';
+import './AnybodyProblem.sol';
+import './Speedruns.sol';
+import '@openzeppelin/contracts/access/Ownable.sol';
+import './BokkyPooBahsDateTimeLibrary.sol';
+import './StringsExtended.sol';
+
 // import "hardhat/console.sol";
 
 /// @title ExternalMetadata
@@ -20,7 +21,153 @@ contract ExternalMetadata is Ownable {
     address payable public speedruns;
     uint256 constant radiusMultiplyer = 100;
 
-    constructor() {}
+    enum ThemeNames {
+        SaturatedExcludeDarks,
+        PastelHighlighterMarker,
+        MarkerPastelHighlighter,
+        ShadowHighlighterMarker,
+        Berlin
+    }
+
+    enum ThemeLayer {
+        BG,
+        Core,
+        FG
+    }
+
+    struct ThemeGroup {
+        ThemeNames name;
+        Theme[3] themes;
+    }
+
+    struct Theme {
+        ThemeLayer layer;
+        uint256 hueStart;
+        uint256 hueEnd;
+        uint256 saturationStart;
+        uint256 saturationEnd;
+        uint256 lightnessStart;
+        uint256 lightnessEnd;
+    }
+
+    ThemeGroup[] public themes;
+
+    constructor() {
+        Theme memory saturated = Theme({
+            layer: ThemeLayer.BG,
+            hueStart: 0,
+            hueEnd: 360,
+            saturationStart: 80,
+            saturationEnd: 100,
+            lightnessStart: 18,
+            lightnessEnd: 100
+        });
+
+        ThemeGroup memory saturatedGroup = ThemeGroup({
+            name: ThemeNames.SaturatedExcludeDarks,
+            themes: [saturated, saturated, saturated]
+        });
+        saturatedGroup.themes[0].layer = ThemeLayer.BG;
+        saturatedGroup.themes[1].layer = ThemeLayer.Core;
+        saturatedGroup.themes[2].layer = ThemeLayer.FG;
+        themes.push(saturatedGroup);
+
+        Theme memory pastelTemplate;
+        pastelTemplate.hueStart = 0;
+        pastelTemplate.hueEnd = 360;
+
+        ThemeGroup memory pastelGroup = ThemeGroup({
+            name: ThemeNames.PastelHighlighterMarker,
+            themes: [pastelTemplate, pastelTemplate, pastelTemplate]
+        });
+        pastelGroup.themes[0].layer = ThemeLayer.BG;
+        pastelGroup.themes[0].saturationStart = 80;
+        pastelGroup.themes[0].saturationEnd = 100;
+        pastelGroup.themes[0].lightnessStart = 85;
+        pastelGroup.themes[0].lightnessEnd = 95;
+
+        pastelGroup.themes[1].layer = ThemeLayer.Core;
+        pastelGroup.themes[1].saturationStart = 100;
+        pastelGroup.themes[1].saturationEnd = 100;
+        pastelGroup.themes[1].lightnessStart = 55;
+        pastelGroup.themes[1].lightnessEnd = 60;
+
+        pastelGroup.themes[2].layer = ThemeLayer.FG;
+        pastelGroup.themes[2].saturationStart = 70;
+        pastelGroup.themes[2].saturationEnd = 90;
+        pastelGroup.themes[2].lightnessStart = 67;
+        pastelGroup.themes[2].lightnessEnd = 67;
+        themes.push(pastelGroup);
+
+        ThemeGroup memory markerGroup = ThemeGroup({
+            name: ThemeNames.MarkerPastelHighlighter,
+            themes: [pastelTemplate, pastelTemplate, pastelTemplate]
+        });
+        markerGroup.themes[0].layer = ThemeLayer.BG;
+        markerGroup.themes[0].saturationStart = 100;
+        markerGroup.themes[0].saturationEnd = 100;
+        markerGroup.themes[0].lightnessStart = 60;
+        markerGroup.themes[0].lightnessEnd = 60;
+
+        markerGroup.themes[1].layer = ThemeLayer.Core;
+        markerGroup.themes[1].saturationStart = 100;
+        markerGroup.themes[1].saturationEnd = 100;
+        markerGroup.themes[1].lightnessStart = 90;
+        markerGroup.themes[1].lightnessEnd = 95;
+
+        markerGroup.themes[2].layer = ThemeLayer.FG;
+        markerGroup.themes[2].saturationStart = 100;
+        markerGroup.themes[2].saturationEnd = 100;
+        markerGroup.themes[2].lightnessStart = 55;
+        markerGroup.themes[2].lightnessEnd = 60;
+        themes.push(markerGroup);
+
+        ThemeGroup memory shadowGroup = ThemeGroup({
+            name: ThemeNames.ShadowHighlighterMarker,
+            themes: [pastelTemplate, pastelTemplate, pastelTemplate]
+        });
+        shadowGroup.themes[0].layer = ThemeLayer.BG;
+        shadowGroup.themes[0].saturationStart = 80;
+        shadowGroup.themes[0].saturationEnd = 100;
+        shadowGroup.themes[0].lightnessStart = 18;
+        shadowGroup.themes[0].lightnessEnd = 25;
+
+        shadowGroup.themes[1].layer = ThemeLayer.Core;
+        shadowGroup.themes[1].saturationStart = 100;
+        shadowGroup.themes[1].saturationEnd = 100;
+        shadowGroup.themes[1].lightnessStart = 55;
+        shadowGroup.themes[1].lightnessEnd = 60;
+
+        shadowGroup.themes[2].layer = ThemeLayer.FG;
+        shadowGroup.themes[2].saturationStart = 70;
+        shadowGroup.themes[2].saturationEnd = 90;
+        shadowGroup.themes[2].lightnessStart = 67;
+        shadowGroup.themes[2].lightnessEnd = 67;
+        themes.push(shadowGroup);
+
+        ThemeGroup memory berlinGroup = ThemeGroup({
+            name: ThemeNames.Berlin,
+            themes: [pastelTemplate, pastelTemplate, pastelTemplate]
+        });
+        berlinGroup.themes[0].layer = ThemeLayer.BG;
+        berlinGroup.themes[0].saturationStart = 100;
+        berlinGroup.themes[0].saturationEnd = 100;
+        berlinGroup.themes[0].lightnessStart = 18;
+        berlinGroup.themes[0].lightnessEnd = 18;
+
+        berlinGroup.themes[1].layer = ThemeLayer.Core;
+        berlinGroup.themes[1].saturationStart = 100;
+        berlinGroup.themes[1].saturationEnd = 100;
+        berlinGroup.themes[1].lightnessStart = 45;
+        berlinGroup.themes[1].lightnessEnd = 45;
+
+        berlinGroup.themes[2].layer = ThemeLayer.FG;
+        berlinGroup.themes[2].saturationStart = 100;
+        berlinGroup.themes[2].saturationEnd = 100;
+        berlinGroup.themes[2].lightnessStart = 30;
+        berlinGroup.themes[2].lightnessEnd = 30;
+        themes.push(berlinGroup);
+    }
 
     // string public baseURI = "https://";
 
@@ -42,23 +189,29 @@ contract ExternalMetadata is Ownable {
 
     /// @dev generates the problemMetadata
     /// @param date the date
-    function getMetadata(
-        uint256 date
-    ) public view returns (string memory) {
+    function getMetadata(uint256 date) public view returns (string memory) {
         return
             string(
                 abi.encodePacked(
-                    "data:application/json;base64,",
+                    'data:application/json;base64,',
                     Base64.encode(
                         abi.encodePacked(
-                            '{"name":"',getName(date), '",',
+                            '{"name":"',
+                            getName(date),
+                            '",',
                             '"description": "Anybody Problem (https://anybody.trifle.life)",',
-                            '"image": "',getSVG(date),'",',
-                            '"image_url": "',getSVG(date),'",',
+                            '"image": "',
+                            getSVG(date),
+                            '",',
+                            '"image_url": "',
+                            getSVG(date),
+                            '",',
                             '"home_url": "https://anybody.trifle.life",',
                             '"external_url": "https://anybody.trifle.life",',
                             // '"animation_url": "', getHTML(tokenId), '",',
-                            '"attributes": ', getAttributes(date), '}'
+                            '"attributes": ',
+                            getAttributes(date),
+                            '}'
                         )
                     )
                 )
@@ -66,10 +219,17 @@ contract ExternalMetadata is Ownable {
     }
 
     function getName(uint256 date) public pure returns (string memory) {
-        (uint year, uint month, uint day) = BokkyPooBahsDateTimeLibrary.timestampToDate(date);
+        (uint year, uint month, uint day) = BokkyPooBahsDateTimeLibrary
+            .timestampToDate(date);
         return
             string(
-                abi.encodePacked(StringsExtended.toString(year),"-",StringsExtended.toString(month),"-",StringsExtended.toString(day))
+                abi.encodePacked(
+                    StringsExtended.toString(year),
+                    '-',
+                    StringsExtended.toString(month),
+                    '-',
+                    StringsExtended.toString(day)
+                )
             );
     }
 
@@ -77,7 +237,7 @@ contract ExternalMetadata is Ownable {
         return
             string(
                 abi.encodePacked(
-                    "data:text/html;base64,",
+                    'data:text/html;base64,',
                     Base64.encode(
                         abi.encodePacked(
                             "<html><body><img src='",
@@ -90,20 +250,18 @@ contract ExternalMetadata is Ownable {
     }
 
     /// @dev function to generate a SVG String
-    function getSVG(
-        uint256 date
-    ) public view returns (string memory) {
+    function getSVG(uint256 date) public view returns (string memory) {
         return
             string(
                 abi.encodePacked(
-                    "data:image/svg+xml;base64,",
+                    'data:image/svg+xml;base64,',
                     Base64.encode(
                         abi.encodePacked(
                             '<?xml version="1.0" encoding="utf-8"?><svg xmlns="http://www.w3.org/2000/svg"  height="100%" width="100%" viewBox="0 0 1000 1000" style="background-color:grey;"><style></style>',
                             getPath(date),
                             '<text x="50" y="550" class="name">',
                             getName(date),
-                            "</text></svg>"
+                            '</text></svg>'
                         )
                     )
                 )
@@ -112,10 +270,13 @@ contract ExternalMetadata is Ownable {
 
     function getPath(uint256 date) public view returns (string memory) {
         // const { seed, bodyCount, tickCount, mintedBodiesIndex } = problem
-        string memory path = "";
+        string memory path = '';
         uint256 scalingFactor = AnybodyProblem(anybodyProblem).scalingFactor();
         uint256 level = AnybodyProblem(anybodyProblem).LEVELS();
-        (AnybodyProblem.Body[6] memory bodies, uint256 bodyCount) = AnybodyProblem(anybodyProblem).generateLevelData(date, level);
+        (
+            AnybodyProblem.Body[6] memory bodies,
+            uint256 bodyCount
+        ) = AnybodyProblem(anybodyProblem).generateLevelData(date, level);
         for (uint256 i = 0; i < bodyCount; i++) {
             AnybodyProblem.Body memory body = bodies[i];
             uint256 scaledRadius = body.radius *
@@ -133,7 +294,7 @@ contract ExternalMetadata is Ownable {
             string memory pxString = string(
                 abi.encodePacked(
                     StringsExtended.toString(pxScaled),
-                    ".",
+                    '.',
                     StringsExtended.toString(pxDecimals)
                 )
             );
@@ -142,46 +303,48 @@ contract ExternalMetadata is Ownable {
             string memory pyString = string(
                 abi.encodePacked(
                     StringsExtended.toString(pyScaled),
-                    ".",
+                    '.',
                     StringsExtended.toString(pyDecimals)
                 )
             );
-            string memory bodyIDString = StringsExtended.toString(body.bodyIndex);
+            string memory bodyIDString = StringsExtended.toString(
+                body.bodyIndex
+            );
             string memory transformOrigin = string(
                 abi.encodePacked(
-                    "transform-origin: ",
+                    'transform-origin: ',
                     pxString,
-                    "px ",
+                    'px ',
                     pyString,
-                    "px; "
+                    'px; '
                 )
             );
             path = string(
                 abi.encodePacked(
                     path,
-                    "<style> @keyframes moveEllipse",
+                    '<style> @keyframes moveEllipse',
                     bodyIDString,
-                    " { 0% { ",
+                    ' { 0% { ',
                     transformOrigin,
-                    " transform: rotate(0deg) translate(0px, 10px); } 100% { ",
+                    ' transform: rotate(0deg) translate(0px, 10px); } 100% { ',
                     transformOrigin,
-                    " transform: rotate(360deg) translate(0px, 10px); } }",
-                    "ellipse#id-",
+                    ' transform: rotate(360deg) translate(0px, 10px); } }',
+                    'ellipse#id-',
                     bodyIDString,
-                    " { animation: moveEllipse",
+                    ' { animation: moveEllipse',
                     bodyIDString,
-                    " 4s infinite linear; animation-delay: -",
+                    ' 4s infinite linear; animation-delay: -',
                     StringsExtended.toString(i),
-                    "s; }</style>",
+                    's; }</style>',
                     '<ellipse id="id-',
                     bodyIDString,
                     '" ry="',
                     radius,
-                    ".",
+                    '.',
                     radiusDecimalsString,
                     '" rx="',
                     radius,
-                    ".",
+                    '.',
                     radiusDecimalsString,
                     '" cy="',
                     pyString,
@@ -203,15 +366,15 @@ contract ExternalMetadata is Ownable {
         uint256 saturation = ((uint256(seed) >> 16) & blocker) % 100;
         uint256 lightness = (((uint256(seed) >> 32) & blocker) % 40) + 40;
         string memory result = string(
-          abi.encodePacked(
-            "hsl(",
-            StringsExtended.toString(color),
-            ",",
-            StringsExtended.toString(saturation),
-            "%,",
-            StringsExtended.toString(lightness),
-            "%)"
-          )
+            abi.encodePacked(
+                'hsl(',
+                StringsExtended.toString(color),
+                ',',
+                StringsExtended.toString(saturation),
+                '%,',
+                StringsExtended.toString(lightness),
+                '%)'
+            )
         );
         return result;
     }
@@ -225,27 +388,47 @@ contract ExternalMetadata is Ownable {
     // }
 
     /// @dev generates the attributes as JSON String
-    function getAttributes(
-        uint256 date
-    ) internal view returns (string memory) {
-        (uint year, uint month, uint day) = BokkyPooBahsDateTimeLibrary.timestampToDate(date);
-        uint256 fastestRunId = AnybodyProblem(anybodyProblem).fastestByDay(date, 0);
-        uint256 secondFastestRunId = AnybodyProblem(anybodyProblem).fastestByDay(date, 1);
-        uint256 thirdFastestRunId = AnybodyProblem(anybodyProblem).fastestByDay(date, 2);
-        (address fastestAddress, , uint256 fastestTime, , ) = AnybodyProblem(anybodyProblem).runs(fastestRunId);
-        (address secondFastestAddress, , uint256 secondFastestTime, , ) = AnybodyProblem(anybodyProblem).runs(secondFastestRunId);
-        (address thirdFastestAddress, , uint256 thirdFastestTime, , ) = AnybodyProblem(anybodyProblem).runs(thirdFastestRunId);
+    function getAttributes(uint256 date) internal view returns (string memory) {
+        (uint year, uint month, uint day) = BokkyPooBahsDateTimeLibrary
+            .timestampToDate(date);
+        uint256 fastestRunId = AnybodyProblem(anybodyProblem).fastestByDay(
+            date,
+            0
+        );
+        uint256 secondFastestRunId = AnybodyProblem(anybodyProblem)
+            .fastestByDay(date, 1);
+        uint256 thirdFastestRunId = AnybodyProblem(anybodyProblem).fastestByDay(
+            date,
+            2
+        );
+        (address fastestAddress, , uint256 fastestTime, , ) = AnybodyProblem(
+            anybodyProblem
+        ).runs(fastestRunId);
+        (
+            address secondFastestAddress,
+            ,
+            uint256 secondFastestTime,
+            ,
+
+        ) = AnybodyProblem(anybodyProblem).runs(secondFastestRunId);
+        (
+            address thirdFastestAddress,
+            ,
+            uint256 thirdFastestTime,
+            ,
+
+        ) = AnybodyProblem(anybodyProblem).runs(thirdFastestRunId);
 
         return
             string(
                 abi.encodePacked(
-                    "[",
+                    '[',
                     '{"trait_type":"Day","value":"',
                     StringsExtended.toString(date),
                     '"}, {"trait_type":"Month","value":"',
                     StringsExtended.toString(year),
                     '-',
-                    Math.log10(month) + 1 == 1 ? "0" : "",
+                    Math.log10(month) + 1 == 1 ? '0' : '',
                     StringsExtended.toString(month),
                     '"}, {"trait_type":"1st Place","value":"',
                     StringsExtended.toHexString(fastestAddress),
@@ -264,10 +447,15 @@ contract ExternalMetadata is Ownable {
             );
     }
 
-    function updateAnybodyProblemAddress(address payable anybodyProblem_) public onlyOwner {
+    function updateAnybodyProblemAddress(
+        address payable anybodyProblem_
+    ) public onlyOwner {
         anybodyProblem = anybodyProblem_;
     }
-    function updateSpeedrunsAddress(address payable speedruns_) public onlyOwner {
+
+    function updateSpeedrunsAddress(
+        address payable speedruns_
+    ) public onlyOwner {
         speedruns = speedruns_;
     }
 }

--- a/src/anybody.js
+++ b/src/anybody.js
@@ -545,8 +545,8 @@ export class Anybody extends EventEmitter {
 
     if (newPauseState) {
       this.pauseBodies = PAUSE_BODY_DATA.map(this.bodyDataToBodies.bind(this))
-      this.pauseBodies[1].c = this.getBodyColor(0)
-      this.pauseBodies[2].c = this.getBodyColor(0)
+      this.pauseBodies[1].c = this.getBodyColor(this.day + 1, 0)
+      this.pauseBodies[2].c = this.getBodyColor(this.day + 2, 0)
       this.paused = newPauseState
       this.willUnpause = false
       delete this.beganUnpauseAt
@@ -800,7 +800,6 @@ export class Anybody extends EventEmitter {
     minBigInt = typeof minBigInt === 'bigint' ? minBigInt : BigInt(minBigInt)
     maxBigInt = typeof maxBigInt === 'bigint' ? maxBigInt : BigInt(maxBigInt)
     seed = typeof seed === 'bigint' ? seed : BigInt(seed)
-    console.log({ seed, maxBigInt, minBigInt })
     return parseInt((seed % (maxBigInt - minBigInt)) + minBigInt)
   }
 
@@ -848,7 +847,6 @@ export class Anybody extends EventEmitter {
   }
 
   getBodyColor(day, bodyIndex = 0) {
-    console.log({ day, bodyIndex })
     let baddieSeed = utils.solidityKeccak256(
       ['uint256', 'uint256'],
       [day, bodyIndex]
@@ -863,9 +861,12 @@ export class Anybody extends EventEmitter {
     const themes = Object.keys(bodyThemes)
     const numberOfThemes = themes.length
     let rand = utils.solidityKeccak256(['uint256'], [day])
-    const bgOptions = 14
-    const fgOptions = 14
+    const faceOptions = 14
+    const bgOptions = 10
+    const fgOptions = 10
     const coreOptions = 1
+    const fIndex = this.randomRange(0, faceOptions - 1, rand)
+    rand = utils.solidityKeccak256(['bytes32'], [rand])
     const bgIndex = this.randomRange(0, bgOptions - 1, rand)
     rand = utils.solidityKeccak256(['bytes32'], [rand])
     const fgIndex = this.randomRange(0, fgOptions - 1, rand)
@@ -876,7 +877,6 @@ export class Anybody extends EventEmitter {
 
     const themeName = themes[dailyThemeIndex]
     const theme = bodyThemes[themeName]
-    console.log({ theme, dailyThemeIndex, bodyThemes })
 
     rand = utils.solidityKeccak256(['bytes32'], [rand])
     const bgHue = this.randomRange(0, 359, rand)
@@ -930,6 +930,7 @@ export class Anybody extends EventEmitter {
     )
 
     const info = {
+      fIndex,
       bgIndex,
       fgIndex,
       coreIndex,
@@ -938,7 +939,6 @@ export class Anybody extends EventEmitter {
       fg: hslToRgb([fgHue, fgSaturation, fgLightness]),
       baddie: [baddieHue, baddieSaturation, baddieLightness]
     }
-    console.log({ info })
     return info
   }
 

--- a/src/colors.js
+++ b/src/colors.js
@@ -47,30 +47,29 @@ export const themes = {
     // random hues
     default: {
       'saturated-exclude-darks': {
-        bg: [undefined, '80-100', '18-100'],
+        bg: [undefined, '80-100', '18-100'], // undefined = 0—359
         cr: [undefined, '80-100', '18-100'],
         fg: [undefined, '80-100', '18-100']
       },
-      'bg:pastel__core:highlighter__fg:marker': {
+      pastel_highlighter_marker: {
         bg: [undefined, '80-100', '85-95'],
-        cr: [undefined, '100', '55-60'],
-        fg: [undefined, '70-90', '67']
+        cr: [undefined, '100-100', '55-60'],
+        fg: [undefined, '70-90', '67-67']
       },
-      'bg:marker__core:pastel__fg:highlighter': {
-        bg: [undefined, '100', '60'],
-        cr: [undefined, '100', '90-95'],
-        fg: [undefined, '100', '55-60']
+      marker_pastel_highlighter: {
+        bg: [undefined, '100-100', '60-60'],
+        cr: [undefined, '100-100', '90-95'],
+        fg: [undefined, '100-100', '55-60']
       },
-      'bg:shadow__core:highlighter__fg:marker': {
+      shadow_highlighter_marker: {
         bg: [undefined, '80-100', '18-25'],
-        cr: [undefined, '100', '55-60'],
-        fg: [undefined, '70-90', '67']
+        cr: [undefined, '100-100', '55-60'],
+        fg: [undefined, '70-90', '67-67']
       },
-      // "berlin"
-      'bg:dark__core:burnt__fg:crayon': {
-        bg: [undefined, '100', '18'],
-        cr: [undefined, '100', '45'],
-        fg: [undefined, '100', '30']
+      berlin: {
+        bg: [undefined, '100-100', '18-18'],
+        cr: [undefined, '100-100', '45-45'],
+        fg: [undefined, '100-100', '30-30']
       }
     },
     // reds / OPTIMISM

--- a/src/visuals.js
+++ b/src/visuals.js
@@ -1499,7 +1499,7 @@ export const Visuals = {
 
         const color = hslToRgb(
           randHSL(
-            themes.bodies.default['bg:pastel__core:highlighter__fg:marker'].cr,
+            themes.bodies.default['pastel_highlighter_marker'].cr,
             this.random.bind(this)
           )
         )
@@ -1656,9 +1656,8 @@ export const Visuals = {
   },
 
   drawFaceSvg(body, width) {
-    const maxIndex = Math.min(FACE_BLINK_SVGS.length, FACE_SVGS.length)
-    this.fIndex ||= this.random(0, maxIndex - 1)
-    const fIndex = (this.fIndex + body.bodyIndex) % maxIndex
+    this.fIndex = body.c.fIndex
+    const { fIndex } = this
     const graphic = body.graphic || this.bodiesGraphic
 
     const baddiesNear = this.closeTo(body)

--- a/src/visuals.js
+++ b/src/visuals.js
@@ -1691,8 +1691,8 @@ export const Visuals = {
     const graphic = body.graphic || this.bodiesGraphic
     graphic.push()
 
-    this.fgIndex ||= this.random(0, FG_SVGS.length - 1)
-    const fgIndex = (this.bgIndex + body.bodyIndex) % FG_SVGS.length
+    this.fgIndex = body.c.fgIndex
+    const { fgIndex } = this
     const r = {
       ...rot.fg,
       ...(rotOverride?.fg?.[fgIndex] ?? {})
@@ -1727,8 +1727,8 @@ export const Visuals = {
     const fill = body.c.bg
     const graphic = body.graphic || this.bodiesGraphic
     graphic.push()
-    this.bgIndex ||= this.random(0, BG_SVGS.length - 1)
-    const bgIndex = (this.bgIndex + body.bodyIndex) % BG_SVGS.length
+    this.bgIndex = body.c.bgIndex
+    const { bgIndex } = this
     const r = {
       ...rot.bg,
       ...(rotOverride?.bg?.[bgIndex] ?? {})


### PR DESCRIPTION
This change should make it possible to have same output of body shapes in color in JS as Solidity for the onchain SVG.

also exposes function `getBodyColor(day, bodyIndex)` that can be used in frontend to help generate bodies. It currently returns:
```js
  {
      fIndex,
      bgIndex,
      fgIndex,
      coreIndex,
      bg: hslToRgb([bgHue, bgSaturation, bgLightness]),
      core: hslToRgb([coreHue, coreSaturation, coreLightness]),
      fg: hslToRgb([fgHue, fgSaturation, fgLightness]),
      baddie: [baddieHue, baddieSaturation, baddieLightness]
    }
```